### PR TITLE
onvalidatemerchant needs to account for failure

### DIFF
--- a/index.php
+++ b/index.php
@@ -120,9 +120,11 @@ document.getElementById("applePay").onclick = function(evt) {
 	session.onvalidatemerchant = function (event) {
 		logit(event);
 		var promise = performValidation(event.validationURL);
-		promise.then(function (merchantSession) {
+		promise.then(function (merchantSession) { /* valid session */
 			session.completeMerchantValidation(merchantSession);
-		}); 
+		}, function(merchantSession) { /* invalid session or adding products to cart in the performValidation fails */
+            session.abort();
+        }); 
 	}
 	
 


### PR DESCRIPTION
I was wracking my brain over why my reject on the session callback function wasn't working on failed sessions. The failure function was not supplied in the ApplePayJS demo, which is fine but if you're new to Promises (as I am) you wonder why the only callback doesn't handle both success/failure. The ApplePay documentation for JS is pretty scarce even if you have access to the Developer Docs.

My main use case is Magento and having an ApplePay button on the product page. The user is expected to view a Product page and hit the ApplePay button and add the current product variation/selection to their cart and generate an order before sending off the paymentData to a payment gateway. With the ApplePay flow you are expected to have totals and shipping amounts so I was adding the product to the users cart after the session validation call but before completely rejecting/resolving the promise. I did not want to present the ApplePay sheet to the user in case the product was not available and I would be able to present the user with an error message.

Thank you for your work, it's been very helpful.